### PR TITLE
fish: remove hardcoded fish_user_paths pointing to author's home dir

### DIFF
--- a/fish/fish_variables
+++ b/fish/fish_variables
@@ -33,7 +33,6 @@ SETUVAR fish_pager_color_description:yellow\x1e\x2di
 SETUVAR fish_pager_color_prefix:normal\x1e\x2d\x2dbold\x1e\x2d\x2dunderline
 SETUVAR fish_pager_color_progress:brwhite\x1e\x2d\x2dbackground\x3dcyan
 SETUVAR fish_pager_color_selected_background:\x2dr
-SETUVAR fish_user_paths:/home/saatvik333/\x2eopencode/bin
 SETUVAR pure_begin_prompt_with_current_directory:true
 SETUVAR pure_check_for_new_release:false
 SETUVAR pure_color_at_sign:pure_color_mute


### PR DESCRIPTION
## Problem

`fish/fish_variables` ships:

```
SETUVAR fish_user_paths:/home/saatvik333/.opencode/bin
```

This is an absolute path into the original author's home directory. On any other user's machine that directory doesn't exist, so after install it ends up as a dead entry in `$PATH`. It's harmless at runtime (fish skips missing dirs), but it's confusing — it surfaces a stranger's username in your `$PATH` and can read like a compromise when auditing the environment.

`fish_user_paths` is inherently machine/user-specific and shouldn't be committed with a hardcoded value.

## Fix

Remove the single line. Fresh installs then start with a clean `fish_user_paths`, and users add their own paths via `fish_add_path` as needed. One-line deletion, no other changes.

## Testing

- Confirmed the diff is a single-line deletion against `main`.
- After removal, a fresh fish session has no bogus `/home/saatvik333/...` entry in `$PATH`.